### PR TITLE
Nano

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
           - charybdisnano
           - planck
           - crkbd
+          - ploopynano
           - test
 
     steps:

--- a/_layouts.h
+++ b/_layouts.h
@@ -42,6 +42,7 @@
 	KC_NO, k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, KC_NO, \
 	                 k32, k33, k34, k35, k36, k37                   \
 
+#define LAYOUT_ploopynano_wrapper(...) LAYOUT(KC_NO)
 
 
 

--- a/keymaps/ploopynano.json
+++ b/keymaps/ploopynano.json
@@ -3,7 +3,7 @@
 	"notes": "",
 	"documentation": "Wrapper based keymap",
 	"keyboard": "ploopyco/trackball_nano",
-	"keymap": "t4corun",
+	"keymap": "lkbm",
 	"layout": "LAYOUT_ploopynano_wrapper",
 	"layers": []
-  }
+}

--- a/keymaps/ploopynano.json
+++ b/keymaps/ploopynano.json
@@ -1,0 +1,8 @@
+{
+	"version": 1,
+	"notes": "",
+	"documentation": "Wrapper based keymap",
+	"keyboard": "ploopyco/trackball_nano",
+	"keymap": "t4corun",
+	"layout": "LAYOUT_ploopynano_wrapper"
+  }

--- a/keymaps/ploopynano.json
+++ b/keymaps/ploopynano.json
@@ -4,5 +4,6 @@
 	"documentation": "Wrapper based keymap",
 	"keyboard": "ploopyco/trackball_nano",
 	"keymap": "t4corun",
-	"layout": "LAYOUT_ploopynano_wrapper"
+	"layout": "LAYOUT_ploopynano_wrapper",
+	"layers": []
   }

--- a/rules.mk
+++ b/rules.mk
@@ -57,7 +57,7 @@ ifeq ($(KEYBOARD), planck/rev6)
 	DIP_SWITCH_ENABLE = no
 endif
 
-ifeq ($(KEYBOARD), ploopyco/trackball_nano)
+ifeq ($(KEYBOARD), ploopyco/trackball_nano/rev1_001)
 #	qmk_firmware\keyboards\ploopyco\trackball_nano\rules.mk
 	CAPS_WORD_ENABLE = no
 	DYNAMIC_MACRO_ENABLE = no

--- a/rules.mk
+++ b/rules.mk
@@ -57,6 +57,9 @@ ifeq ($(KEYBOARD), planck/rev6)
 	DIP_SWITCH_ENABLE = no
 endif
 
+ifeq ($(KEYBOARD), ploopyco/trackball_nano)
+#	qmk_firmware\keyboards\ploopyco\trackball_nano\rules.mk
+endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
 	SRC += features/rgbmatrix.c

--- a/rules.mk
+++ b/rules.mk
@@ -59,6 +59,9 @@ endif
 
 ifeq ($(KEYBOARD), ploopyco/trackball_nano)
 #	qmk_firmware\keyboards\ploopyco\trackball_nano\rules.mk
+	CAPS_WORD_ENABLE = no
+	DYNAMIC_MACRO_ENABLE = no
+	COMBO_ENABLE = no
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)


### PR DESCRIPTION
Integrating the Ploopy Nano into my QMK Userspace
- Right now it is building the lkbm keymap that is in QMK Firmware because it has drag scroll/dpi switching/bootloader enabled by Host Status (caps lock, numlock)
- Next I will update my keymap to redo the mouse layer so the ploopy nano works better